### PR TITLE
Fix broken schedule runner on a fresh install

### DIFF
--- a/app/Http/Controllers/Backend/BackendScheduleController.php
+++ b/app/Http/Controllers/Backend/BackendScheduleController.php
@@ -72,37 +72,43 @@ class BackendScheduleController extends Controller
     }
 
       public function push_rate_limits(){
-        $rate_limits = cache()->get('rate_limits');
+        $rate_limits = cache()->get('rate_limits', []);
         $rate_limits_collection = collect($rate_limits);
         $rate_limits_chunks = $rate_limits_collection->chunk(5000);
         foreach($rate_limits_chunks as $rate_limits_chunk){
-            \App\Models\RateLimit::insert($rate_limits_chunk->toArray());
+            if ($rate_limits_chunk->count() > 0) {
+                \App\Models\RateLimit::insert($rate_limits_chunk->toArray());
+            }
         }
-        dump("rate_limits pushed ".count($rate_limits));
+        dump("rate_limits pushed ".count($rate_limits ?? []));
         cache()->forget('rate_limits');
         
 
 
 
-        $rate_limit_details = cache()->get('rate_limit_details');
+        $rate_limit_details = cache()->get('rate_limit_details', []);
         $rate_limit_details_collection = collect($rate_limit_details);
         $rate_limit_details_chunks = $rate_limit_details_collection->chunk(5000);
         foreach($rate_limit_details_chunks as $rate_limit_details_chunk){
-            \App\Models\RateLimitDetail::insert($rate_limit_details_chunk->toArray());
+            if ($rate_limit_details_chunk->count() > 0) {
+                \App\Models\RateLimitDetail::insert($rate_limit_details_chunk->toArray());
+            }
         }
-        dump("rate_limit_details pushed ".count($rate_limit_details));
+        dump("rate_limit_details pushed ".count($rate_limit_details ?? []));
         cache()->forget('rate_limit_details');
 
 
 
 
-        $item_seens = cache()->get('item_seens');
+        $item_seens = cache()->get('item_seens', []);
         $item_seens_collection = collect($item_seens);
         $item_seens_chunks = $item_seens_collection->chunk(5000);
         foreach($item_seens_chunks as $item_seens_chunk){
-            \App\Models\ItemSeen::insert($item_seens_chunk->toArray());
+            if ($item_seens_chunk->count() > 0) {
+                \App\Models\ItemSeen::insert($item_seens_chunk->toArray());
+            }
         }
-        dump("item_seens pushed ".count($item_seens));
+        dump("item_seens pushed ".count($item_seens ?? []));
         cache()->forget('item_seens');
     }
 


### PR DESCRIPTION
Fixes #2

## Summary

Handled potential runtime errors when running the schedular on a fresh install / machine by:

1. Adding fallbacks when accessing keys from cache.
2.  Checking the length of chunks before attempting to process them.
3. Adding fallbacks for potential `null` values of accessed cache keys.