### PR TITLE
Remove national_id column from detainee seeder

### DIFF
--- a/database/migrations/2025_04_07_161954_add_national_id_column_to_detainees_table.php
+++ b/database/migrations/2025_04_07_161954_add_national_id_column_to_detainees_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('detainees', function (Blueprint $table) {
+            $table->string('national_id')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('detainee', function (Blueprint $table) {
+            $table->dropColumn('national_id');
+        });
+    }
+};


### PR DESCRIPTION
Fixes #14 

## Summary

Removes `national_id` column in [DetaineeSeeder.php](https://github.com/amolood/aseer-platform/blob/c90f8786ecb9d4496e502d2a4fbba58b4b43d60c/database/seeders/DetaineeSeeder.php) as it was dropeed in this commit eb6f2f51151a57599308d050e1cf07832264abc1