### PR TITLE
remove national id from the seeder

### DIFF
--- a/database/seeders/DetaineeSeeder.php
+++ b/database/seeders/DetaineeSeeder.php
@@ -15,7 +15,6 @@ class DetaineeSeeder extends Seeder
                 'name' => 'محمد أحمد',
                 'gender' => 'male',
                 'birth_date' => '1982-09-20',
-                'national_id' => '6098603874',
                 'location' => 'الرياض',
                 'detention_date' => '2024-08-25',
                 'status' => 'martyr',


### PR DESCRIPTION
This pull request removes the national_id field from the detainee seeder in the Platform. Since the national_id is no longer part of the detainee model, this update ensures consistency between the model and the seeder. The fix addresses issues with new databases by aligning the seeder with the current model structure. Existing databases remain unaffected.